### PR TITLE
Agregar soporte para Ktor: implementar cliente HTTP multiplataforma y…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.kotlinxSerialization) // Aplicar plugin de serialización
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
     
     sourceSets {
         val desktopMain by getting
-        val wasmJsMain by getting
+        // val wasmJsMain by getting
         
         androidMain.dependencies {
             implementation(compose.preview)
@@ -54,6 +54,9 @@ kotlin {
             implementation(libs.decompose.extensions.compose.jetpack.v080)
             //implementation(libs.decompose)
             implementation(libs.kotlinx.serialization)
+
+            // Ktor
+            implementation(libs.ktor.client.okhttp)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -70,6 +73,14 @@ kotlin {
             //implementation(libs.decompose.jetbrains)
             //implementation(libs.decompose)
             implementation(libs.kotlinx.serialization)
+
+            // Ktor
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+
+            // Ktor for JS
+            implementation(libs.ktor.client.js)
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
@@ -77,10 +88,21 @@ kotlin {
             implementation(libs.arkivanov.decompose.v080)
             //implementation(libs.decompose.extensions.compose.jetpack.v080)
             implementation(libs.decompose.jetbrains)
+
+            // Ktor
+            implementation(libs.ktor.client.cio.jvm)
         }
-        wasmJsMain.dependencies {
-            //implementation("org.jetbrains.compose.web:compose-web-router:1.0.0-beta6")
-            implementation(libs.kotlinx.serialization)
+        val wasmJsMain by getting {
+            dependencies {
+                //implementation("org.jetbrains.compose.web:compose-web-router:1.0.0-beta6")
+                implementation(libs.kotlinx.serialization)
+
+                // Ktor
+                implementation(libs.ktor.client.js)
+                implementation(libs.ktor.client.content.negotiation) // Faltaba
+                implementation(libs.ktor.serialization.kotlinx.json) // Faltaba
+                implementation(libs.kotlinx.serialization) // Requerido
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/connexuss/project/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/connexuss/project/MainActivity.kt
@@ -5,6 +5,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,4 +25,12 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun AppAndroidPreview() {
     App()
+}
+
+actual fun createHttpClient(): HttpClient = HttpClient(OkHttp) {
+    install(ContentNegotiation) {
+        json(Json {
+            ignoreUnknownKeys = true
+        })
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/App.kt
@@ -9,6 +9,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import org.connexuss.project.navegacion.Navegacion
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 
 @Composable
 @Preview
@@ -31,3 +34,17 @@ fun App() {
         )
     }
 }
+/*
+// Declaración "expect" para crear el cliente HTTP en cada plataforma
+expect fun createHttpClient(): HttpClient
+
+// Función compartida para hacer una petición GET a una URL (por ejemplo, a la API REST de Firebase)
+suspend fun fetchFirebaseData(url: String): String {
+    val client = createHttpClient()
+    // Realiza una solicitud GET y obtiene el cuerpo como texto
+    val response: HttpResponse = client.get(url)
+    val text = response.bodyAsText()
+    client.close()
+    return text
+}
+ */

--- a/composeApp/src/desktopMain/kotlin/org/connexuss/project/main.kt
+++ b/composeApp/src/desktopMain/kotlin/org/connexuss/project/main.kt
@@ -2,6 +2,11 @@ package org.connexuss.project
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 
 fun main() = application {
     Window(
@@ -9,5 +14,13 @@ fun main() = application {
         title = "ConneXus_serverless",
     ) {
         App()
+    }
+}
+
+actual fun createHttpClient(): HttpClient = HttpClient(CIO) {
+    install(ContentNegotiation) {
+        json(Json {
+            ignoreUnknownKeys = true
+        })
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/connexuss/project/HttpClientFactory.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/connexuss/project/HttpClientFactory.kt
@@ -1,0 +1,16 @@
+package org.connexuss.project
+/*
+import io.ktor.client.*
+import io.ktor.client.engine.js.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+
+actual fun createHttpClient(): HttpClient = HttpClient(Js) {
+    install(ContentNegotiation) {
+        json(Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false  // Necesario para JS/WASM
+        })
+    }
+}
+ */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,9 @@ kotlinxSerialization = "1.7.0"
 foundationAndroid = "1.7.8"
 animationCoreLint = "1.8.0-beta03"
 
+# Ktor
+ktor = "2.3.7"
+
 [libraries]
 arkivanov-decompose-v080 = { module = "com.arkivanov.decompose:decompose", version.ref = "arkivanovDecompose" }
 core = { module = "kotlinx.io.core:core", version.ref = "core" }
@@ -59,11 +62,20 @@ kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 androidx-animation-core-lint = { group = "androidx.compose.animation", name = "animation-core-lint", version.ref = "animationCoreLint" }
 
+# Ktor
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-cio-jvm = { module = "io.ktor:ktor-client-cio-jvm", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
+
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+
 # plugin de serializadcion de kotlin
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        maven{ url = uri("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental") }
     }
 }
 


### PR DESCRIPTION
… actualizar dependencias en build.gradle.kts para la serialización y negociación de contenido. Sin embargo, la implementación del cliente HTTP en web/wasm da error con los imports (hay que revisarlo a fondo)