### PR TITLE
Renombrar campos en UsuarioPrueba y actualizar repositorios: se cambi…

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/AppFirebase.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/AppFirebase.kt
@@ -6,6 +6,16 @@ import androidx.navigation.NavHostController
 
 @Composable
 fun AppFirebase(navHostController: NavHostController) {
+
+    // Repositorios
     val repositorioUsuarios = remember { FirestoreUsuariosRepositorio() }
-    PantallaUsuario(repositorioUsuarios)
+    val repositorioMensajes = remember { FirestoreMensajesRepositorio() }
+    val repositorioConversaciones = remember { FirestoreConversacionesRepositorio() }
+    val repositorioConversacionesUsuarios = remember { FirestoreConversacionesUsuariosRepositorio() }
+    val repositorioPosts = remember { FirestorePostsRepositorio() }
+    val repositorioHilos = remember { FirestoreHilosRepositorio() }
+    val repositorioTemas = remember { FirestoreTemasRepositorio() }
+
+    // Pantallas
+    PantallaUsuario(repositorioUsuarios, navHostController)
 }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/EnMemoriaUsuariosRepositorio.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/EnMemoriaUsuariosRepositorio.kt
@@ -12,10 +12,10 @@ class EnMemoriaUsuariosRepositorio : UsuariosRepositorio {
     init {
         usuarios.value = List(15) {
             UsuarioPrueba(
-                id = "ID: $it",
-                name = "User $it",
-                title = "Title $it",
-                company = "Company $it"
+                idUsuarioPrueba = "ID: $it",
+                nombre = "User $it",
+                titulo = "Title $it",
+                compannia = "Company $it"
             )
         }
     }
@@ -25,20 +25,20 @@ class EnMemoriaUsuariosRepositorio : UsuariosRepositorio {
     }
 
     override fun getUsuarioPorId(id: String): Flow<UsuarioPrueba?> {
-        return usuarios.map { userList -> userList.find { it.id == id } }
+        return usuarios.map { userList -> userList.find { it.idUsuarioPrueba == id } }
     }
 
     override suspend fun addUsuario(usuarioPrueba: UsuarioPrueba) {
-        usuarios.value += usuarioPrueba.copy(id = (id++).toString())
+        usuarios.value += usuarioPrueba.copy(idUsuarioPrueba = (id++).toString())
     }
 
     override suspend fun updateUsuario(usuarioPrueba: UsuarioPrueba) {
         usuarios.value = usuarios.value.map {
-            if (it.id == usuarioPrueba.id) usuarioPrueba else it
+            if (it.idUsuarioPrueba == usuarioPrueba.idUsuarioPrueba) usuarioPrueba else it
         }
     }
 
     override suspend fun deleteUsuario(usuarioPrueba: UsuarioPrueba) {
-        usuarios.value = usuarios.value.filter { it.id != usuarioPrueba.id }
+        usuarios.value = usuarios.value.filter { it.idUsuarioPrueba != usuarioPrueba.idUsuarioPrueba }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/FirestoreUsuariosRepositorio.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/FirestoreUsuariosRepositorio.kt
@@ -28,15 +28,15 @@ class FirestoreUsuariosRepositorio : UsuariosRepositorio {
         val userId = generateRandomStringId()
         firestore.collection(nombreColeccion)
             .document(userId)
-            .set(usuarioPrueba.copy(id = userId))
+            .set(usuarioPrueba.copy(idUsuarioPrueba = userId))
     }
 
     override suspend fun updateUsuario(usuarioPrueba: UsuarioPrueba) {
-        firestore.collection(nombreColeccion).document(usuarioPrueba.id).set(usuarioPrueba)
+        firestore.collection(nombreColeccion).document(usuarioPrueba.idUsuarioPrueba).set(usuarioPrueba)
     }
 
     override suspend fun deleteUsuario(usuarioPrueba: UsuarioPrueba) {
-        firestore.collection(nombreColeccion).document(usuarioPrueba.id).delete()
+        firestore.collection(nombreColeccion).document(usuarioPrueba.idUsuarioPrueba).delete()
     }
 
     private fun generateRandomStringId(length: Int = 20): String {

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/HojaContenidoAbajo.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/HojaContenidoAbajo.kt
@@ -18,9 +18,9 @@ fun HojaContenidoAbajo(
     onSave: (UsuarioPrueba) -> Unit,
     onDelete: (UsuarioPrueba?) -> Unit
 ) {
-    var nombre by remember { mutableStateOf(usuarioPrueba?.name ?: "") }
-    var titulo by remember { mutableStateOf(usuarioPrueba?.title ?: "") }
-    var compannia by remember { mutableStateOf(usuarioPrueba?.company ?: "") }
+    var nombre by remember { mutableStateOf(usuarioPrueba?.nombre ?: "") }
+    var titulo by remember { mutableStateOf(usuarioPrueba?.titulo ?: "") }
+    var compannia by remember { mutableStateOf(usuarioPrueba?.compannia ?: "") }
 
     Column(
         modifier = Modifier
@@ -55,7 +55,7 @@ fun HojaContenidoAbajo(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
-            Button(onClick = { onSave(UsuarioPrueba(usuarioPrueba?.id ?: "", nombre, titulo, compannia)) }) {
+            Button(onClick = { onSave(UsuarioPrueba(usuarioPrueba?.idUsuarioPrueba ?: "", nombre, titulo, compannia)) }) {
                 Text(text = if (usuarioPrueba == null) "Guardar" else "Actualizar")
             }
             Button(onClick = { onDelete(usuarioPrueba) }) {

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/ItemUsuario.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/ItemUsuario.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.connexuss.project.interfaces.LimitaTamanioAncho
 
 @Composable
 fun ItemUsuario(usuarioPrueba: UsuarioPrueba, clicked: () -> Unit) {
@@ -22,11 +23,11 @@ fun ItemUsuario(usuarioPrueba: UsuarioPrueba, clicked: () -> Unit) {
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            Text(text = usuarioPrueba.name, style = MaterialTheme.typography.titleMedium)
+            Text(text = usuarioPrueba.nombre, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = usuarioPrueba.title, style = MaterialTheme.typography.bodyMedium)
+            Text(text = usuarioPrueba.titulo, style = MaterialTheme.typography.bodyMedium)
             Spacer(modifier = Modifier.height(2.dp))
-            Text(text = usuarioPrueba.company, style = MaterialTheme.typography.bodySmall)
+            Text(text = usuarioPrueba.compannia, style = MaterialTheme.typography.bodySmall)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/ListaUsuarios.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/ListaUsuarios.kt
@@ -17,7 +17,7 @@ fun ListaUsuarios(usuarioPruebas: List<UsuarioPrueba>, modifier: Modifier = Modi
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        items(usuarioPruebas, key = { it.id }) { user ->
+        items(usuarioPruebas, key = { it.idUsuarioPrueba }) { user ->
             ItemUsuario(usuarioPrueba = user) {
                 userClicked(user)
             }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/PantallaUsuario.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/PantallaUsuario.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import kotlinx.coroutines.launch
+import org.connexuss.project.interfaces.DefaultTopBar
 
 @Composable
-fun PantallaUsuario(repository: UsuariosRepositorio) {
+fun PantallaUsuario(repository: UsuariosRepositorio, navHostController: NavHostController) {
     val scope = rememberCoroutineScope()
     val users by repository.getUsuario().collectAsState(emptyList())
     PantallaUsuarioContenido(
@@ -21,6 +23,7 @@ fun PantallaUsuario(repository: UsuariosRepositorio) {
         addUser = { scope.launch { repository.addUsuario(it) } },
         updateUser = { scope.launch { repository.updateUsuario(it) } },
         deleteUser = { scope.launch { repository.deleteUsuario(it) } },
+        navHostController = navHostController
     )
 }
 
@@ -31,6 +34,7 @@ fun PantallaUsuarioContenido(
     addUser: (UsuarioPrueba) -> Unit,
     updateUser: (UsuarioPrueba) -> Unit,
     deleteUser: (UsuarioPrueba) -> Unit,
+    navHostController: NavHostController
 ) {
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
@@ -39,8 +43,12 @@ fun PantallaUsuarioContenido(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("User List") }
+            DefaultTopBar(
+                title = "Usuarios",
+                navController = navHostController,
+                showBackButton = true,
+                irParaAtras = true,
+                muestraEngranaje = true
             )
         },
         floatingActionButton = {

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/PruebasObjetosFirebase.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/PruebasObjetosFirebase.kt
@@ -1,0 +1,64 @@
+package org.connexuss.project.firebase.pruebas
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import org.connexuss.project.interfaces.DefaultTopBar
+
+@Composable
+fun MuestraObjetosPruebasFriebase(navHostController: NavHostController) {
+
+    /*
+    // Repositorios
+    val repositorioUsuarios = remember { FirestoreUsuariosRepositorio() }
+    val repositorioMensajes = remember { FirestoreMensajesRepositorio() }
+    val repositorioConversaciones = remember { FirestoreConversacionesRepositorio() }
+    val repositorioConversacionesUsuarios = remember { FirestoreConversacionesUsuariosRepositorio() }
+    val repositorioPosts = remember { FirestorePostsRepositorio() }
+    val repositorioHilos = remember { FirestoreHilosRepositorio() }
+    val repositorioTemas = remember { FirestoreTemasRepositorio() }
+
+    // Pantallas
+    PantallaUsuario(repositorioUsuarios, navHostController)
+     */
+
+    Scaffold(
+        topBar = {
+            DefaultTopBar(
+                title = "Objetos Pruebas Firebase",
+                navController = navHostController,
+                showBackButton = true,
+                irParaAtras = true,
+                muestraEngranaje = true
+            )
+        }
+    ) {
+        val tiposObjetos = listOf(
+            "UsuarioPrueba",
+            "Mensaje",
+            "Conversacion",
+            "ConversacionUsuario",
+            "Post",
+            "Hilo",
+            "Tema"
+        )
+
+        tiposObjetos.forEach { objeto ->
+            Button(
+                onClick = {
+                    navHostController.navigate("pruebas/$objeto")
+                },
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(text = objeto, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/UsuarioPrueba.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/pruebas/UsuarioPrueba.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UsuarioPrueba(
-    val id: String,
-    val name: String,
-    val title: String,
-    val company: String
+    val idUsuarioPrueba: String,
+    val nombre: String,
+    val titulo: String,
+    val compannia: String
 )

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Sistema.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Sistema.kt
@@ -1736,7 +1736,7 @@ fun PantallaLogin(navController: NavHostController) {
                         }
                         Spacer(modifier = Modifier.height(16.dp))
                         Button(
-                            onClick = { navController.navigate("appFirebase") },
+                            onClick = { navController.navigate("appFirebase") /*navController.navigate("pruebasObjetosFIrebase")*/ },
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             //Text(traducir("debug_ir_a_home"))

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/navegacion/Navegacion.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/navegacion/Navegacion.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import org.connexuss.project.datos.UsuarioPrincipal
 import org.connexuss.project.firebase.pruebas.AppFirebase
+import org.connexuss.project.firebase.pruebas.MuestraObjetosPruebasFriebase
 import org.connexuss.project.interfaces.PantallaAjustesAyuda
 import org.connexuss.project.interfaces.PantallaAjustesControlCuentas
 import org.connexuss.project.interfaces.PantallaCambiarTema
@@ -122,6 +123,9 @@ fun Navegacion(
         }
         composable("appFirebase") {
             AppFirebase(navController)
+        }
+        composable("pruebasObjetosFIrebase") {
+            MuestraObjetosPruebasFriebase(navController)
         }
     }
 }


### PR DESCRIPTION
…an los nombres de los campos de 'id', 'name', 'title' y 'company' a 'idUsuarioPrueba', 'nombre', 'titulo' y 'compannia' respectivamente, y se ajustan los repositorios y pantallas para reflejar estos cambios.