### PR TITLE
Actualizar identificadores de tipo Uuid a String en modelos de datos:…

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/comunicacion/ChatModelos.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/comunicacion/ChatModelos.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package org.connexuss.project.comunicacion
 
 import kotlinx.datetime.Clock
@@ -48,7 +47,7 @@ class ChatService(private val chatRepository: ChatRepository) {
  */
 @Serializable
 data class Mensaje (
-    val id: Uuid = generateId(),
+    val id: String = generateId(),
     val senderId: String,
     val receiverId: String,
     val content: String,
@@ -67,8 +66,8 @@ data class Mensaje (
  */
 @Serializable
 data class Conversacion (
-    val id: Uuid = generateId(),
-    val participants: List<Uuid>,
+    val id: String = generateId(),
+    val participants: List<String>,
     val messages: List<Mensaje> = emptyList(),
     val nombre: String? = null
 ) {
@@ -92,14 +91,18 @@ data class Conversacion (
 data class ConversacionesUsuario(
     val id: String,
     val idUser: String,
-    val conversaciones: List<Uuid> = emptyList(),
+    val conversaciones: List<String> = emptyList(),
 )
 
 /**
  * Genera un identificador único.
  *
- * @return Uuid generado aleatoriamente.
+ * @return String generado aleatoriamente.
  */
-fun generateId(): Uuid {
-    return Uuid.random()
+fun generateId(): String {
+    val valores = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    val longitud = 20
+    return (1..longitud)
+        .map { valores.random() }
+        .joinToString("")
 }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/comunicacion/ForoModelos.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/comunicacion/ForoModelos.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package org.connexuss.project.comunicacion
 
 import kotlinx.datetime.Clock
@@ -20,9 +19,9 @@ import kotlin.uuid.Uuid
  */
 @Serializable
 data class Post(
-    val idPost: Uuid = generateId(),
-    val idSender: Uuid,
-    val idReceiver: Uuid,
+    val idPost: String = generateId(),
+    val idSender: String,
+    val idReceiver: String,
     val content: String,
     val fechaPost: LocalDateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 )
@@ -37,9 +36,9 @@ data class Post(
  */
 @Serializable
 data class Hilo(
-    val idHilo: Uuid = generateId(),
-    val idForeros: List<Uuid>,
-    val idPosts: List<Uuid> = emptyList(),
+    val idHilo: String = generateId(),
+    val idForeros: List<String>,
+    val idPosts: List<String> = emptyList(),
     val nombre: String? = null
 )
 
@@ -53,8 +52,8 @@ data class Hilo(
  */
 @Serializable
 data class Tema(
-    val idTema: Uuid = generateId(),
-    val idUsuario: Uuid,
+    val idTema: String = generateId(),
+    val idUsuario: String,
     val nombre: String,
-    val idHilos: List<Uuid> = emptyList()
+    val idHilos: List<String> = emptyList()
 )

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/ItemObjetos.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/firebase/ItemObjetos.kt
@@ -173,9 +173,9 @@ fun ItemPost(post: Post, clicked: () -> Unit) {
         ) {
             Text(text = post.idPost, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = post.senderId, style = MaterialTheme.typography.titleMedium)
+            Text(text = post.idSender, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = post.receiverId, style = MaterialTheme.typography.titleMedium)
+            Text(text = post.idReceiver, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
             Text(text = post.content, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
@@ -203,7 +203,7 @@ fun ItemHilo(hilo: Hilo, clicked: () -> Unit) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(text = hilo.idForeros.toString(), style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = hilo.posts.toString(), style = MaterialTheme.typography.titleMedium)
+            Text(text = hilo.idPosts.toString(), style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
             Text(text = hilo.nombre.toString(), style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
@@ -229,7 +229,7 @@ fun ItemTema(tema: Tema, clicked: () -> Unit) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(text = tema.idUsuario, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = tema.hilos.toString(), style = MaterialTheme.typography.titleMedium)
+            Text(text = tema.idHilos.toString(), style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(4.dp))
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Chats.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Chats.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package org.connexuss.project.interfaces
 
 import androidx.compose.foundation.Image
@@ -44,8 +43,6 @@ import org.connexuss.project.misc.UsuarioPrincipal
 import org.connexuss.project.misc.UsuariosPreCreados
 import org.connexuss.project.misc.Imagen
 import org.jetbrains.compose.resources.painterResource
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 /**
  * Muestra el chat entre dos usuarios.
@@ -55,17 +52,15 @@ import kotlin.uuid.Uuid
  * @param chatId Identificador de la conversación.
  */
 @Composable
-fun mostrarChat(navController: NavHostController, chatId : Uuid?) {
+fun mostrarChat(navController: NavHostController, chatId : String?) {
     // Obtiene la lista de conversaciones y busca la que tenga el id pasado
 
     val listaChats = UsuarioPrincipal?.getChatUser()?.conversaciones
     val chat = listaChats?.find { it == chatId } ?: return
 
-    val otherParticipantId = chat.participants.firstOrNull {
-        it != (UsuarioPrincipal?.getIdUnico() ?: "")
-    }
+    val otherParticipantId = chat.participants.find { it != UsuarioPrincipal?.getIdUnico() }
         ?: chat.participants.getOrNull(1) ?: ""
-    // nombre del otro participante en UsuariosPreCreados:
+
     val otherParticipantUser = UsuariosPreCreados.find { it.getIdUnico() == otherParticipantId }
     val otherParticipantName = UsuariosPreCreados.find { it.getIdUnico() == otherParticipantId }?.getNombreCompleto() ?: otherParticipantId
 

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Foro.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/interfaces/Foro.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
-
 package org.connexuss.project.interfaces
 
 import androidx.compose.foundation.clickable
@@ -23,7 +21,6 @@ import kotlinx.coroutines.launch
 import org.connexuss.project.comunicacion.*
 import org.connexuss.project.misc.ForoRepository
 import org.connexuss.project.misc.temasHilosPosts
-import kotlin.uuid.ExperimentalUuidApi
 
 @Composable
 fun ForoScreen(navController: NavHostController) {

--- a/composeApp/src/commonMain/kotlin/org/connexuss/project/misc/Datos.kt
+++ b/composeApp/src/commonMain/kotlin/org/connexuss/project/misc/Datos.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package org.connexuss.project.misc
 
 import androidx.compose.runtime.mutableStateListOf
@@ -24,7 +23,6 @@ import org.connexuss.project.comunicacion.Tema
 import org.connexuss.project.usuario.AlmacenamientoUsuario
 import org.connexuss.project.usuario.UtilidadesUsuario
 import org.connexuss.project.usuario.Usuario
-import kotlin.uuid.ExperimentalUuidApi
 
 // Imagenes App -----------------------------------------------------
 


### PR DESCRIPTION
… se modificaron las clases Mensaje, Conversacion, ConversacionesUsuario, Post, Hilo y Tema para utilizar String en lugar de Uuid, y se implementó una nueva función generateId() para generar identificadores aleatorios.